### PR TITLE
Do not open serial connection when connecting to a socket://

### DIFF
--- a/serial_asyncio_fast/__init__.py
+++ b/serial_asyncio_fast/__init__.py
@@ -513,10 +513,13 @@ async def create_serial_connection(
     """
     parsed_url = urllib.parse.urlparse(url)
 
-    callback = partial(serial.serial_for_url, url, *args, **kwargs)
-    serial_instance = await loop.run_in_executor(None, callback)
-
     if parsed_url.scheme == "socket":
+        if "do_not_open" not in kwargs:
+            kwargs["do_not_open"] = True
+
+        callback = partial(serial.serial_for_url, url, *args, **kwargs)
+        serial_instance = await loop.run_in_executor(None, callback)
+
         transport, protocol = await loop.create_connection(
             protocol_factory, parsed_url.hostname, parsed_url.port
         )
@@ -527,6 +530,9 @@ async def create_serial_connection(
         transport._extra["serial"] = serial_instance
         serial_instance._socket = transport.get_extra_info("socket")._sock
     else:
+        callback = partial(serial.serial_for_url, url, *args, **kwargs)
+        serial_instance = await loop.run_in_executor(None, callback)
+
         transport, protocol = await connection_for_serial(
             loop, protocol_factory, serial_instance
         )


### PR DESCRIPTION
Do not open serial connection when connecting to a `socket://` as `loop.create_connection` takes care of that.

Fixes #12 