### PR TITLE
Add py.typed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,7 @@ setup(
     author="pySerial-team",
     url="https://github.com/home-assistant-libs/pyserial-asyncio-fast",
     packages=['serial_asyncio_fast'],
+    package_data={'serial_asyncio_fast': ['py.typed']},
     install_requires=[
         'pyserial',
     ],


### PR DESCRIPTION
This enables downstream code to actually use the type hints added in 5abd0be26d1228411b3ee8ddaa513374a48f5b98
