### PR TITLE
BaseException should not be caught

### DIFF
--- a/serial_asyncio_fast/__init__.py
+++ b/serial_asyncio_fast/__init__.py
@@ -310,7 +310,7 @@ class SerialTransport(asyncio.Transport):
         except serial.SerialException as exc:
             self._fatal_error(exc, "Fatal write error on serial transport")
             return
-        except BaseException as exc:
+        except Exception as exc:
             self._fatal_error(exc, "Unhandled fatal write error on serial transport")
             return
         else:
@@ -402,7 +402,7 @@ class SerialTransport(asyncio.Transport):
         self._low_water = low
 
     def _fatal_error(
-        self, exc: BaseException, message="Fatal error on serial transport"
+        self, exc: Exception, message="Fatal error on serial transport"
     ) -> None:
         """Report a fatal error to the event-loop and abort the transport."""
         self._loop.call_exception_handler(
@@ -437,7 +437,7 @@ class SerialTransport(asyncio.Transport):
             self._remove_writer()
             _create_background_task(self._call_connection_lost(exc, flush=True))
 
-    def _abort(self, exc: Optional[BaseException]) -> None:
+    def _abort(self, exc: Optional[Exception]) -> None:
         """Close the transport immediately.
 
         Pending operations will not be given opportunity to complete,


### PR DESCRIPTION
Per the exception [heirarchy](https://docs.python.org/3/library/exceptions.html#exception-hierarchy), there are 3 Exceptions derived from `Exception` and not `BaseException`.

- `KeyboardInterrupt`
- `SystemExit`
- `GeneratorExit`

`KeyboardInterrupt` and `SystemExit` are typically not caught, as Python is closing anyways.  I believe catching them interferes with e.g. CTRL+C.

`GeneratorExit` does not seem relevant here.  Even if it were, it must be re-raised or `RuntimeError: generator ignored GeneratorExit` will occur.

I therefore propose changing all usages of `except BaseException` to `except Exception`.

This resolves a single error with `pyright` or `mypy`.  However, it _does_ technically represent a change from `pyserial`.
