### PR TITLE
fix defered writes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,6 +21,7 @@ jobs:
         cache: "pip"
     - name: Install dependencies
       run: |
+        sudo apt-get update && sudo apt-get install -y socat
         python -m pip install --upgrade pip
         pip install -r requirements_dev.txt .
     - name: Tests

--- a/serial_asyncio_fast/__init__.py
+++ b/serial_asyncio_fast/__init__.py
@@ -20,6 +20,7 @@ import os
 import logging
 import urllib.parse
 from functools import partial
+from select import poll, POLLOUT
 from typing import Any, Callable, Coroutine, List, Optional, Set, Tuple, Union
 
 import serial
@@ -74,6 +75,8 @@ class SerialTransport(asyncio.Transport):
         self._has_writer = False
         self._poll_wait_time = 0.0005
         self._max_out_waiting = 1024
+        self._write_poll = poll()
+        self._write_poll.register(self._serial.fileno(), POLLOUT)
 
         # XXX how to support url handlers too
 
@@ -151,16 +154,20 @@ class SerialTransport(asyncio.Transport):
         if self._closing:
             return
 
-        if not self._write_buffer:
-            # Try to send the data right away if the buffer is empty.
-            # If this fails, the data will be added to the buffer
-            self._write_data(data)
-            return
+        # Polling here is needed to make sure that writing would not block.
+        # Otherwise we get a deadlock because PySerial will infinitely retry
+        # to write the data.
+        if not self._write_buffer and self._write_poll.poll(0):
+                # Try to send the data right away if the buffer is empty.
+                # If this fails, the data will be added to the buffer.
+                self._write_data(data)
+                return
 
         # If we get here, the buffer was not empty
         # so we just append the data to it and wait
         # for the next _write_ready callback.
         self._write_buffer.append(data)
+        self._ensure_writer()
         self._maybe_pause_protocol()
 
     def can_write_eof(self) -> bool:
@@ -286,6 +293,12 @@ class SerialTransport(asyncio.Transport):
         registered with the asyncio event-loop against the
         underlying file descriptor for the serial port.
         """
+        if not self._write_buffer:
+            # Nothing to write anymore. We need to remove the writer, otherwise
+            # we'll get called again and again for no reason.
+            self._remove_writer()
+            return
+
         if len(self._write_buffer) == 1:
             data = self._write_buffer.pop()
         else:

--- a/test/test_asyncio.py
+++ b/test/test_asyncio.py
@@ -16,6 +16,7 @@ device connected, use:
 """
 
 import os
+import subprocess
 import unittest
 import asyncio
 from typing import Optional
@@ -102,6 +103,77 @@ class Test_asyncio(unittest.TestCase):
         all_data = b"".join(received)
         self.assertEqual(all_data, COMPLETE_MESSAGE)
         self.assertEqual(actions, ["open", "close"])
+
+class AsyncTests(unittest.IsolatedAsyncioTestCase):
+    async def test_remove_writer(self) -> None:
+        TEXT = b"Hello, World!"
+        COUNT = 8 * 1024
+
+        IN_TTY = "/tmp/ttyTestIn"
+        OUT_TTY = "/tmp/ttyTestOut"
+
+        # Use socat to create a pair of linked PTYs to simulate two connected
+        # serial ports.
+        socat = subprocess.Popen(
+            ["socat", f"pty,link={IN_TTY},raw,echo=0", f"pty,link={OUT_TTY},raw,echo=0"]
+        )
+
+        # Give socat some time to set up the PTYs.
+        await asyncio.sleep(0.5)
+        self.assertIsNone(socat.poll(), "socat process exited unexpectedly")
+
+        output_resume_event = asyncio.Event()
+
+        class Input(asyncio.Protocol):
+            """
+            Echoes back whatever data it receives.
+            """
+            def connection_made(self, transport: asyncio.BaseTransport) -> None:
+                assert isinstance(transport, serial_asyncio_fast.SerialTransport)
+                self._transport = transport
+
+            def data_received(self, data: bytes) -> None:
+                self._transport.write(data)
+
+        class Output(asyncio.Protocol):
+            """
+            Provides backpressure to writer via output_resume_event.
+            """
+            def connection_made(self, transport: asyncio.BaseTransport) -> None:
+                assert isinstance(transport, serial_asyncio_fast.SerialTransport)
+                self._transport = transport
+                output_resume_event.set()
+
+            def pause_writing(self) -> None:
+                output_resume_event.clear()
+
+            def resume_writing(self) -> None:
+                output_resume_event.set()
+
+        loop = asyncio.get_running_loop()
+
+        in_transport, _ = await serial_asyncio_fast.create_serial_connection(loop, Input, IN_TTY)
+        out_transport, _ = await serial_asyncio_fast.create_serial_connection(loop, Output, OUT_TTY)
+
+        # Write a bunch of data so that we create a buffer and a writer.
+        for _ in range(COUNT):
+            await asyncio.wait_for(output_resume_event.wait(), timeout=5)
+            out_transport.write(TEXT)
+
+        # Ensure that we actually sent enough data to have a writer added to
+        # the event loop.
+        self.assertTrue(out_transport._has_writer)
+
+        # Then make sure that the writer is removed when the buffer is drained.
+        async def poll_has_writer() -> None:
+            while out_transport._has_writer:
+                await asyncio.sleep(0.1)
+
+        await asyncio.wait_for(poll_has_writer(), timeout=5)
+
+        out_transport.close()
+        in_transport.close()
+        socat.terminate()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The `SerialTransport.write()` method was not actually handling deferred writes correctly. There were a number of issues with it.

1.  When a large amount of data was written, it would begin with a direct write to the serial port. Some, but not all of the data would be written. The remainder would be put in the `_write_buffer` and a writer would be added to the event loop.

    Once the buffer was drained, there was nothing to remove the writer from the event loop. This caused it to continually wake up and call `_write_ready()`, which would find no data to write and crash with an `AssertionError`.

This is fixed by checking for no data in `_write_ready()` and removing the writer from the event loop at that point.

Fixing that exposed the next issue.

2.  If data is written in chunks that exactly match the underlying serial port buffer size, then doing a direct write could deadlock. When the buffer is full, the write will raise an `OSError` with `EWOULDBLOCK`. PySerial catches this and retries the write indefinitely, hence the deadlock. This blocks the `asyncio` event loop from running at all.

To fix this issue, we register a poll object when the transport is created. Then before doing a direct write, we poll the serial port to make sure that writing will not block. If it would block, we skip the direct write and go straight to buffering the data and adding the writer to the event loop.

Fixing this exposed another issue.

3.  If the direct write was skipped, there was nothing to add the writer to the event loop. This caused the buffered data to never be sent.

This is fixed by calling `_ensure_writer()` when the direct write is skipped.

A test is added that fails without these fixes and passes with them. PyTest catches the `AssertionError` from 1 even though it happens in a background task. Pytest (or the CI runner) should eventually time out when 2 happens. And 3 triggers a `TimeoutError` in the test waiting for one of the conditions to be met.